### PR TITLE
CP-54706: Send pause command to xenguest earlier

### DIFF
--- a/emum.c
+++ b/emum.c
@@ -102,6 +102,13 @@ struct emu {
     uint64_t sent;
     uint64_t remaining;
     int iter;
+
+    /*
+     * Send the pause command as soon as the live_done state is reached.
+     * This may be useful to avoid the live copy slowing down the VM's suspend
+     * operations.
+     */
+    bool fast_pause;
 };
 
 struct stream_fd {
@@ -185,7 +192,8 @@ struct emu emus[] = {
         .exp_total = 1000000,
         .stream = NULL,
         .status = not_done,
-        .iter = -1
+        .iter = -1,
+        .fast_pause = true,
     },
     {
         .name = "vgpu",
@@ -1650,6 +1658,18 @@ static bool check_live_not_finished(struct emu *emu)
  */
 static bool check_not_ready(struct emu *emu)
 {
+    if (emu->status == live_done && emu->fast_pause) {
+        int rc;
+
+        emu->fast_pause = false;
+
+        rc = emp_client_send_cmd(emu->client, cmd_migrate_pause);
+        if (rc)
+            log_err("Error sending fast pause: %d, %s", -rc, strerror(-rc));
+        else
+            emu->enabled &= ~STAGE_PAUSE;
+    }
+
     return (emu->enabled & STAGE_READY) && emu->status == not_done;
 }
 
@@ -1792,6 +1812,8 @@ static int configure_emus(void)
             log_err("Error adding vgpu argument: %d, %s", -rc, strerror(-rc));
             return rc;
         }
+
+        xenguest->fast_pause = false;
     }
     return 0;
 }


### PR DESCRIPTION
When emu-manager decides that xenguest has done enough in the live phase, it sets the state to live_done and then proceeds to suspend the VM. While the VM is executing its suspend process, xenguest continues to copy dirtied pages and this can slow down the suspend process.

In cases where vgpu is not used, it is preferable to send the pause command as soon as the live_done state is reached. This prevents excessive iterations from xenguest, lets the VM's suspend process run quickly, and the overall migration finish faster.

Measurements of the time from "xenguest live stage is done" to "Finished, send complete":

Before: 1020 ms, 1284 ms, 1263 ms
After: 439 ms, 470 ms, 431 ms